### PR TITLE
Various fixes from testing of samples

### DIFF
--- a/nanoFramework.Networking.Thread/OpenThread.cs
+++ b/nanoFramework.Networking.Thread/OpenThread.cs
@@ -187,6 +187,7 @@ namespace nanoFramework.Networking.Thread
             if (!_started)
             {
                 NativeStartThread();
+                _started = true;
             }
             else
             {

--- a/nanoFramework.Networking.Thread/OpenThreadDataset.cs
+++ b/nanoFramework.Networking.Thread/OpenThreadDataset.cs
@@ -11,6 +11,7 @@ namespace nanoFramework.Networking.Thread
     /// <summary>
     /// Represents a OpenThread Dataset.
     /// </summary>
+    [Serializable]
     public class OpenThreadDataset
     {
         private UInt16 _channel;

--- a/nanoFramework.Networking.Thread/OpenThreadJoinerStartCompleteEventArgs.cs
+++ b/nanoFramework.Networking.Thread/OpenThreadJoinerStartCompleteEventArgs.cs
@@ -19,6 +19,6 @@ namespace nanoFramework.Networking.Thread
         /// <summary>
         /// Joiner start error or 0 if successful.
         /// </summary>
-        public int error { get => _error; set => value = _error; }
+        public int error { get => _error; set => _error = value; }
     }
 }


### PR DESCRIPTION
## Description

-  Unable to stop after starting OpenThread
-  Make OpenThreadDataset serializable
-  Joiner event error code not set correctly

## Motivation and Context

Fixes form testing samples


## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Locally

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
